### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Implements the user dashboard for REVERSE_LC REDCap projects!
 
 ## Participant Status Definitions
 
-1. Screened
+1. Pre-Screened
 Criteria: [continue_yn] == '1' || [continue_yn] == '99'
 
 2. Enrolled

--- a/REVERSE_LC.php
+++ b/REVERSE_LC.php
@@ -298,8 +298,7 @@ class REVERSE_LC extends \ExternalModules\AbstractExternalModule {
 	{
         if(!$this->screening_data) {
             if(!$projectId) {
-				$edcProjectId = $this->getProjectSetting('edc_project');
-                $projectId    = $edcProjectId;
+				$projectId = $_GET['pid'];
             }
 
             $screeningProjectId = $this->getProjectSetting("screening_project", $projectId);
@@ -309,7 +308,7 @@ class REVERSE_LC extends \ExternalModules\AbstractExternalModule {
 				"return_format" => "json",
                 'exportDataAccessGroups' => true
             ]));
-			
+
 			$screeningProject = new \Project($screeningProjectId);
 			preg_match_all("/<li>(.+)$/m", $screeningProject->metadata['excl_desc_4']['element_label'], $labels);
 			$this->excl_desc_labels = $labels[1];
@@ -779,6 +778,7 @@ class REVERSE_LC extends \ExternalModules\AbstractExternalModule {
 	}
 	public function getScreeningLogData($site = null, $first_day_of_week = 0) {
 		// determine earliest screened date (upon which weeks array will be based)
+		
 		$screening_data = $this->getScreeningData();
 		$first_date = date("Y-m-d");
 		$last_date = date("Y-m-d", 0);
@@ -822,13 +822,14 @@ class REVERSE_LC extends \ExternalModules\AbstractExternalModule {
 			
 			// count records that were screened this week
 			$ts_a = strtotime($date1);
-			$ts_b = strtotime("+24 hours", strtotime($date2));
+			$ts_b = strtotime("+23 hours 59 minutes 59 seconds", strtotime($date2));
 			// echo "\$date1, \$date2, \$ts_a, \$ts_b: $date1, $date2, $ts_a, $ts_b\n";
 			foreach ($screening_data as $record) {
 				$ts_x = strtotime($record->dos);
 				$site_match_or_null = $site === null ? true : $record->redcap_data_access_group == $site;
-				if ($ts_a <= $ts_x and $ts_x <= $ts_b and $site_match_or_null)
+				if ($ts_a <= $ts_x && $ts_x <= $ts_b && $site_match_or_null) {
 					$screened_this_week++;
+				}
 			}
 			$total_screened += $screened_this_week;
 			

--- a/REVERSE_LC.php
+++ b/REVERSE_LC.php
@@ -89,7 +89,7 @@ class REVERSE_LC extends \ExternalModules\AbstractExternalModule {
 	public $personnel_roles = [
 		'PI',
 		'Primary Coordinator',
-		'Primary dispensing pharmacist'
+		'Primary Pharmacist'
 	];
 	public $document_signoff_fields = [
 		'cv' => 'cv_review_vcc',
@@ -1252,9 +1252,10 @@ class REVERSE_LC extends \ExternalModules\AbstractExternalModule {
 			}
 		}
 		unset($data);
-		
 		$this->processStartupPersonnelData($startup_data->personnel, $startup_data->dags);
 		$this->processStartupSiteData($startup_data->sites, $startup_data->personnel);
+		
+
 		$startup_data->errors = $this->startup_errors;
 		
 		return $startup_data;
@@ -1521,7 +1522,6 @@ class REVERSE_LC extends \ExternalModules\AbstractExternalModule {
 				}
 			}
 		}
-		
 		$personnel_data = $personnel;
 	}
 	public function processStartupSiteData(&$sites, $personnel) {
@@ -1531,7 +1531,6 @@ class REVERSE_LC extends \ExternalModules\AbstractExternalModule {
 					unset($site->$key);
 			}
 		}
-		
 		$reg_pid = $this->getProjectSetting('site_regulation_project');
 		$reg_project = new \Project($reg_pid);
 		$personnel_event_id = array_key_first($reg_project->events[2]['events']);

--- a/config.json
+++ b/config.json
@@ -42,7 +42,7 @@
 		},
 		{
 			"key": "screening_project",
-			"name": "Screening Project ID",
+			"name": "Pre-Screening Project ID",
 			"required": false,
 			"type": "project-id",
 			"repeatable": false

--- a/templates/_screening.html.twig
+++ b/templates/_screening.html.twig
@@ -1,19 +1,19 @@
 <div class="row justify-content-center  text-center content-menu mb-4" id="screeningMenu">
     <div class="col-2">
-        <button data-report='screening_log' onclick="showReport(this)" class="border-0 h-100 p-4 btn btn-primary bg-teal">Screening Log Report</button>
+        <button data-report='screening_log' onclick="showReport(this)" class="border-0 h-100 p-4 btn btn-primary bg-teal">Pre-Screening Log Report</button>
     </div>
     <div class="col-2">
-        <button data-report='exclusion' onclick="showReport(this)" class="border-0 h-100 p-4 btn btn-primary bg-green">Exclusion Report</button>
+        <button data-report='exclusion' onclick="showReport(this)" class="border-0 h-100 p-4 btn btn-primary bg-green">Pre-Screening Exclusion Report</button>
     </div>
     <div class="col-2">
-        <button data-report='screen_fail' onclick="showReport(this)"class="border-0 h-100 p-4 btn btn-primary bg-orange">Screening Fail Report</button>
+        <button data-report='screen_fail' onclick="showReport(this)"class="border-0 h-100 p-4 btn btn-primary bg-orange">Pre-Screening Fail Report</button>
    </div>   
 </div>
 
 <div class="content-container d-none" data-menu='screeningMenu' id="screening_log">
     <div class="row">
         <div class="col-12 text-center">
-            <h3 class="mb-4">Screening Log Report</h3>
+            <h3 class="mb-4">Pre-Screening Log Report</h3>
         </div>    
         <div class="col-6">
             {# dropdown #}
@@ -29,8 +29,8 @@
                 <thead>
                     <tr>
                         <th>Week</th>
-                        <th>Sum of Prescreened</th>
-                        <th>Cumulative Prescreened</th>
+                        <th>Sum of Pre-Screened</th>
+                        <th>Cumulative Pre-Screened</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -70,7 +70,7 @@
                     data: {
                         labels: week_labels,
                         datasets: [{
-                            label: 'Participants Screened',
+                            label: 'Participants Pre-Screened',
                             data: data1,
                             {# backgroundColor: 'rgba(255, 99, 132, 0.2)', #}
                             borderColor: 'rgba(13, 127, 133, 1)',
@@ -80,7 +80,7 @@
                                 anchor: 'center'
                             }
                         },{
-                            label: 'Cumulative Screened',
+                            label: 'Cumulative Pre-Screened',
                             data: data2,
                             backgroundColor: 'rgba(180, 199, 231, 1)',
                             borderWidth: 1,
@@ -94,7 +94,7 @@
                             display: true,
                             fontSize: 24,
                             fontStyle: 'normal',
-                            text: 'Participant Screening'
+                            text: 'Participant Pre-Screening'
                         },
                         scales: {
                             yAxes: [{
@@ -112,7 +112,7 @@
 <div class="content-container d-none" data-menu='screeningMenu' id="exclusion">
     <div class="row">
         <div class="col-12 text-center">
-            <h3 class="mb-3">Exclusion Report</h3>
+            <h3 class="mb-3">Pre-Screening Exclusion Report</h3>
         </div>
         <div class="col-6">
             {# table #}
@@ -196,7 +196,7 @@
 <div class="content-container d-none" data-menu='screeningMenu' id="screen_fail">
     <div class="row">
         <div class="col-12 text-center">
-            <h3 class="mb-3">Screen Fail Report</h3>
+            <h3 class="mb-3">Pre-Screening Fail Report</h3>
         </div>
         <div class="col-6">
             {# table #}
@@ -243,7 +243,7 @@
                     data: {
                         labels: fail_labels,
                         datasets: [{
-                            label: 'Screening Failures',
+                            label: 'Pre-Screening Failures',
                             data: fail_counts,
                             borderColor: 'rgba(13, 127, 133, 1)',
                             backgroundColor: 'rgba(13, 127, 133, 1)',

--- a/templates/dashboard.twig
+++ b/templates/dashboard.twig
@@ -17,7 +17,7 @@
     </li>
     <li class="nav-item" role="presentation">
       <button class="nav-link" id="tab3-tab" data-bs-toggle="tab" data-bs-target="#screening" type="button" role="tab" aria-controls="tab3" aria-selected="false">
-		Screening
+		Pre-Screening
 		</button>
     </li>
 	<li class="nav-item" role="presentation">
@@ -42,7 +42,7 @@
 							<th>Site Activation Date</th>
 							<th>FPE</th>
 							<th>LPE</th>
-							<th>Screened</th>
+							<th>Pre-Screened</th>
 							<th>Eligible</th>
 							<th>Randomized</th>
 							<th>Consented</th>


### PR DESCRIPTION
# Pre-flight Checklist
- [x] Are all the features in this PR tested? 
- [x] Have other features this PR touches also been tested?
- [x] Has the code been formatted for consistency and readability?
- [x] Did you also update related documentation and tooling, such as .readme or tests?

# Overview
## Updates

### Language Update
- Update all “Screened/Screening” language to “Pre-Screened/Pre-Screening” for clarity that this is coming from our Pre-Screening database.

### Enrollment Statistics Tab
- Rename the "Screened" column to "Pre-Screened".

### Screening Tab
- Rename the "Screening" tab to "Pre-Screening".
- Rename the "Screening Log Report" to "Pre-Screening Log Report".
- Update the legend from "Participants Screened/Cumulative Screened" to "Participants Pre-Screened/Cumulative Pre-Screened".
- Rename the "Exclusion Report" to "Pre-Screening Exclusion Report".
- Rename the "Screening Fail Report" to "Pre-Screening Fail Report".
- Update the legend from "Screening Failures" to "Pre-Screening Failures".

### Discrepancies
- The number of screened on the Enrollment Statistics tab and the number of cumulative screened on the Screening Log report do not match.
- There are only 78 records in the Pre-Screening database, but 79 Cumulative Screened on the Screening Log Report.

### Site Activation Tab
- The Primary Dispensing Pharmacist error is showing for all sites, but this role does not exist in the REVERSE-LC Regulatory Database.
- It is believed that the Primary Dispensing Pharmacist role existed in NECTAR. The role variable `[role]` and value for pharmacist (8) are consistent with NECTAR, but the label has changed to “Primary Pharmacist”.
- There are multiple personnel listed under the Primary Pharmacist role, so further internal discussion is needed to determine who in this role should be checked for documents.
# Context
https://redcap.vumc.org/external_modules/?prefix=REVERSE-LC&page=dashboard&pid=179659

